### PR TITLE
Upgrade to v1.1.2.

### DIFF
--- a/simple-jwt-jjwt/src/main/java/cn/org/codecrafters/simplejwt/jjwt/JjwtTokenResolver.java
+++ b/simple-jwt-jjwt/src/main/java/cn/org/codecrafters/simplejwt/jjwt/JjwtTokenResolver.java
@@ -186,7 +186,7 @@ public class JjwtTokenResolver implements TokenResolver<Jws<Claims>> {
                 .setId(jtiCreator.nextId().toString());
 
         if (claims != null && !claims.isEmpty()) {
-            builder.setClaims(claims);
+            builder.addClaims(claims);
         }
 
         return builder.signWith(key, algorithm)


### PR DESCRIPTION
## Fixes

- Fixed the issue that predefined payloads in Token are deleted after adding custom Claims.
- Fixed the issue that cannot create the bean of `JjwtTokenResolver` with a 32-character secret.